### PR TITLE
Added debug argument to configure function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,9 +15,10 @@ SOS._serverEndpoint = 'https://onesignal.com/api/v1';
 /***
  * This method sets up the module with the required API keys to use OneSignal
  */
-SOS.prototype.configure = function(appId, restKey) {
+SOS.prototype.configure = function(appId, restKey, debug) {
     SOS._appId = appId;
     SOS._restKey = restKey;
+    SOS._debug = debug;
 };
 
 /**
@@ -90,8 +91,8 @@ SOS.prototype._execHttpRequest = function(url, method, data, cb) {
 
     // Inject App ID into payload
     data.app_id = SOS._appId;
-
-    console.log(data);
+    
+    if (SOS._debug) console.log(data);
 
     request.post({
         url: url,


### PR DESCRIPTION
I moved the console.log call behind a conditional that only runs if the debug argument was passed as true to the configure function. I was getting way too much clutter in my console, when that visibility is only needed in a testing environment.