### PR TITLE
Improved error handling when invalid JSON is returned by OneSignal (closes #4)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -107,12 +107,23 @@ SOS.prototype._execHttpRequest = function(url, method, data, cb) {
             cb(null, responseBody);
         } else {
             if(typeof responseBody !== 'undefined') {
-                var errorResponse = JSON.parse(responseBody);
-                if(typeof errorResponse.errors !== 'undefined') {
-                    cb(util.format("OneSignal came back with errors: %s", errorResponse.errors.join(', ')));
-                } else {
-                    cb('Could not connect to OneSignal, HTTP error: ' + response.statusCode);
+                //Define an empty variable for errorResponse.
+                var errorResponse = null;
+                
+                //We are expecting JSON from OneSignal. To be safe, let's wrap
+                try{
+                    errorResponse = JSON.parse(responseBody);
+                } catch(error){
+                    return cb('OneSignal returned invalid JSON: ' + responseBody);
                 }
+           
+                //Return the one or more errors OneSignal gave us.
+                if(errorResponse && typeof errorResponse.errors !== 'undefined') {
+                    return cb(util.format("OneSignal came back with errors: %s", errorResponse.errors.join(', ')));
+                }
+                
+                cb('Could not connect to OneSignal, HTTP error: ' + response.statusCode);
+                
             } else {
                 cb('Error connecting to OneSignal! HTTP response code ' + response.statusCode);
             }

--- a/src/index.js
+++ b/src/index.js
@@ -104,29 +104,28 @@ SOS.prototype._execHttpRequest = function(url, method, data, cb) {
         body: JSON.stringify(data)
     }, function(err, response, responseBody) {
         if(!err && response.statusCode === 200) {
-            cb(null, responseBody);
+            return cb(null, responseBody);
         } else {
             if(typeof responseBody !== 'undefined') {
-                //Define an empty variable for errorResponse.
+                //Define an empty variable for errorResponse. We'll populate this from inside the following try block.
                 var errorResponse = null;
                 
-                //We are expecting JSON from OneSignal. To be safe, let's wrap
+                //We are expecting JSON from OneSignal. Let's wrap this in a try/catch so we're protected from formatting errors on OneSignal's side.
                 try{
                     errorResponse = JSON.parse(responseBody);
                 } catch(error){
                     return cb('OneSignal returned invalid JSON: ' + responseBody);
                 }
            
-                //Return the one or more errors OneSignal gave us.
+                //If we can understand the data, return the one or more errors OneSignal gave us.
                 if(errorResponse && typeof errorResponse.errors !== 'undefined') {
                     return cb(util.format("OneSignal came back with errors: %s", errorResponse.errors.join(', ')));
-                }
-                
-                cb('Could not connect to OneSignal, HTTP error: ' + response.statusCode);
-                
-            } else {
-                cb('Error connecting to OneSignal! HTTP response code ' + response.statusCode);
+                }   
             }
+            
+            //We are unable to interpret the data from OneSignal in a useful way.
+            //Let's return a generic error.
+            return cb('Error connecting to OneSignal! HTTP response code ' + response.statusCode);
         }
     });
 };


### PR DESCRIPTION
Hey there,

I've accounted for the situations where OneSignal returns invalid JSON that I reported in #4.

After further investigation I have a feel it might be related to rate-limiting for us (LeSalon), but in any case the problem is real and this should stop it from happening again.

I also commented each logic step when processing errors and combined the two identical fallback errors into one place in the code. Hope this is acceptable.

NF